### PR TITLE
remove double quotes around ${standard} in validator.ts and formatter.ts

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -39,7 +39,7 @@ export class Formatter implements DocumentRangeFormattingEditProvider {
     const isFullDocument = Formatter.isFullDocumentRange(range, document);
 
     const args = [
-      `--standard="${standard}"`,
+      `--standard=${standard}`,
       excludes.length && !isFullDocument ? `--exclude="${excludes.join(',')}"` : '',
       '-',
     ];

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -129,7 +129,7 @@ export class Validator {
 
     const args = [
       '--report=json',
-      `--standard="${standard}"`,
+      `--standard=${standard}`,
       '-q',
     ];
 


### PR DESCRIPTION
Because with doubles quote, VSCode 1.30.2 failed with :
PHPCBF: ERROR: the ""Drupal"" coding standard is not installed