### PR TITLE
Pass stdin-path to phpcbf

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -46,6 +46,10 @@ export class Formatter implements DocumentRangeFormattingEditProvider {
       args.set('exclude', excludes.join(','));
     }
 
+    if (document.uri.scheme === 'file') {
+      args.set('stdin-path', document.uri.fsPath);
+    }
+
     const spawnOptions = {
       cwd: workspace.workspaceFolders && workspace.workspaceFolders[0].uri.scheme === 'file'
         ? workspace.workspaceFolders[0].uri.fsPath


### PR DESCRIPTION
Since 232cfba the validator passes the filename to phpcs, so it respects all include and exclude patterns. However, when the code is formatted the filename isn't passed, which led to unexpected results.

This makes the same change that was made to phpcs to phpcbf, so they both behave the same and autofixing files takes into account the include/exclude rules.