### PR TITLE
Allow for spaces in path to `phpcs` and `phpcbf`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to the "PHP Sniffer" extension will be documented in this file.
 
 ## [Unreleased]
+### Fixed
+- Fix error with unquoted spaces with `executablesFolder` in Windows
 
 ## [1.2.5] - 2020-05-06
 ### Fixed

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -7,6 +7,17 @@ const { spawn } = require('child_process');
 const { stringsList } = require('./strings');
 
 /**
+ * Quotes a string if it contains spaces and not already double-quote quoted.
+ *
+ * @param {string} string
+ *   The string to possibly quote.
+ *
+ * @return {string}
+ *   Result string.
+ */
+const quoteSpaces = (string) => (string.includes(' ') && !string.includes('"') ? `"${string}"` : string);
+
+/**
  * Maps CLI argument map into a formatted array of strings.
  *
  * @param {Map<string, string>} args
@@ -19,7 +30,7 @@ const { stringsList } = require('./strings');
  */
 module.exports.mapToCliArgs = (args, quote = false) => Array.from(args.entries())
   .filter(([key, value]) => value !== '' && key !== '')
-  .map(([key, value]) => `--${key}=${quote && value.includes(' ') ? `"${value}"` : value}`);
+  .map(([key, value]) => `--${key}=${(quote && quoteSpaces(value)) || value}`);
 
 /**
  * Converts a close event to a promise.
@@ -109,7 +120,12 @@ module.exports.CliCommandError = CliCommandError;
  */
 async function executeCommand(options) {
   const { command, token, stdin = '', spawnOptions = {} } = options;
-  const cliProcess = spawn(command, options.args || [], spawnOptions);
+  const cliProcess = spawn(
+    // Fix spaces in command in Windows shell (nodejs/node#7367).
+    (spawnOptions.shell && quoteSpaces(command)) || command,
+    options.args || [],
+    spawnOptions,
+  );
 
   token.onCancellationRequested(() => !cliProcess.killed && cliProcess.kill());
 

--- a/test/unit/cli.test.js
+++ b/test/unit/cli.test.js
@@ -72,5 +72,18 @@ suite('CLI Utilities', function () {
         }),
       );
     });
+
+    test('Command with spaces', async function () {
+      const result = await executeCommand({
+        command: './command with spaces',
+        token: createStubToken(),
+        spawnOptions: {
+          shell: process.platform === 'win32',
+          cwd: __dirname,
+        },
+      });
+
+      strictEqual(result, 'foo');
+    });
   });
 });

--- a/test/unit/command with spaces
+++ b/test/unit/command with spaces
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#
+# Script for cli.test.js
+#
+
+echo -n 'foo';

--- a/test/unit/command with spaces.bat
+++ b/test/unit/command with spaces.bat
@@ -1,0 +1,7 @@
+::
+:: Script for cli.test.js
+::
+
+@Echo off
+
+echo echo | set /p output=foo


### PR DESCRIPTION
Add quotes to `phpcs` and `phpcbf` commands so that they work with spaces in the path.

Without this change, you will get an error if the path to the executables folder has spaces in it.