### PR TITLE
Fix: Compatibility with Windows Paths

### DIFF
--- a/lib/files.php
+++ b/lib/files.php
@@ -40,5 +40,12 @@ foreach ($this->ruleset->paths as $ruleset_path) {
 // There are file directives, and the processing file did not match any of them;
 // ignore the processing file.
 if ($has_files) {
+  // This code fix ensures compatibility with Windows paths by converting them
+  // to use forward slashes, addressing a "Compilation failed" warning
+  // related to preg_match in PHP_CodeSniffer.
+  if (DIRECTORY_SEPARATOR === '\\') {
+    $processing_file = str_replace(DIRECTORY_SEPARATOR, '/', $processing_file);
+  }
+
   $this->ruleset->ignorePatterns[$processing_file] = 'absolute';
 }


### PR DESCRIPTION
This pull request addresses a compatibility issue with Windows paths in PHP_CodeSniffer. When the system uses backslashes (e.g., `\\`) as directory separators on Windows, it can lead to problems in pattern matching with `preg_match`.

To fix this issue, we have added a conditional check to ensure that Windows paths are consistently using forward slashes (e.g., `/`) as directory separators before adding them to the ignore patterns. This change ensures that paths are correctly matched and ignored, even on Windows systems.

This should resolve the "Compilation failed" warning related to `preg_match` that you've encountered. 

Please review this pull request and let us know if it solves your problem. If you have any further comments or suggestions, feel free to share them. Thank you!