### PR TITLE
Update PHP_CodeSniffer repository link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ All notable changes to the "PHP Sniffer" extension will be documented in this fi
   - `phpSniffer.standard` and `phpSniffer.executablesFolder` are now evaluated
     per file — relative paths are relative to the file's workspace folder.
   - Since there is a current working directory to work with, this change means
-    [PHP_CodeSniffer can detect common ruleset config files](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file)
+    [PHP_CodeSniffer can detect common ruleset config files](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file)
     in a more expected way.
 - Respect `<file>` tags in ruleset files
 - `phpSniffer.executablesFolder` no longer requires trailing slash

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.com/wongjn/vscode-php-sniffer.svg?branch=master)](https://travis-ci.com/wongjn/vscode-php-sniffer)
 [![PHP Sniffer on the Visual Studio Marketplace](https://vsmarketplacebadge.apphb.com/version-short/wongjn.php-sniffer.svg)](https://marketplace.visualstudio.com/items?itemName=wongjn.php-sniffer)
 
-Uses [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) to format
+Uses [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) to format
 and lint (mainly) PHP code.
 
 ## Features
@@ -25,7 +25,7 @@ and lint (mainly) PHP code.
 ## Requirements
 
 - [PHP](https://php.net)
-- [PHP_Codesniffer](https://github.com/squizlabs/PHP_CodeSniffer)
+- [PHP_Codesniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer)
 
 ## Extension Settings
 
@@ -78,7 +78,7 @@ only if `phpSniffer.executablesFolder` is empty).
 * `phpSniffer.standard`: The standards to check against. This is passed to the
 `phpcbf` and `phpcs` executables as the value for `--standard`. Can be absolute,
 or relative to the workspace folder. If not set,
-[PHP_CodeSniffer will attempt to find a file to use](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file),
+[PHP_CodeSniffer will attempt to find a file to use](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file),
 at the root of the currently open file's workspace folder in the following order:
   1. `.phpcs.xml`
   2. `phpcs.xml`

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -117,7 +117,7 @@ const createRunner = (token, uri, fullDocument = true) => {
   if (uri.scheme === 'file') {
     args.set('stdin-path', uri.fsPath);
     // Use the same logic that is in PHP_CodeSniffer to parse the file's
-    // extension (see https://github.com/squizlabs/PHP_CodeSniffer/blob/3.5.8/src/Files/File.php#L242).
+    // extension (see https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/3.5.8/src/Files/File.php#L242).
     args.set('extensions', uri.path.split('.').pop() || '');
   }
   if (standard) args.set('standard', standard);

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
                     "scope": "resource",
                     "type": "string",
                     "default": "",
-                    "markdownDescription": "The standards to check against. This is passed to the `phpcbf` and `phpcs` executables as the value for `--standard`. Can be absolute, or relative to the workspace folder. If not set, [PHP_CodeSniffer will attempt to find a file to use](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file)."
+                    "markdownDescription": "The standards to check against. This is passed to the `phpcbf` and `phpcs` executables as the value for `--standard`. Can be absolute, or relative to the workspace folder. If not set, [PHP_CodeSniffer will attempt to find a file to use](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file)."
                 },
                 "phpSniffer.snippetExcludeSniffs": {
                     "scope": "resource",

--- a/test/integration/phpcs-report.test.js
+++ b/test/integration/phpcs-report.test.js
@@ -29,7 +29,7 @@ suite('Report Utilities', function () {
 
     test('A report is flattened correctly', function () {
       // Report taken from PHP_CodeSniffer Github wiki Reports page.
-      // https://github.com/squizlabs/PHP_CodeSniffer/wiki/Reporting#printing-a-json-report
+      // https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Reporting#printing-a-json-report
       const messages = [
         {
           message: 'Missing file doc comment',


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932